### PR TITLE
fixes to compile on OS X (tested 10.8.5)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CFLAGS := -I include
-CLEAN := ignore-xend.so assert-test assert-test.o has-tsx
+CLEAN := ignore-xend.so assert-test assert-test.o has-tsx tsx-assert.o
 
 all: ignore-xend.so assert-test has-tsx tsx-assert.o 
 


### PR DESCRIPTION
Confirms that mid-2013 MacBook Airs have support for RTM and HLE.

Note: also requires updating /usr/lib/clang/4.2/include/cpuid.h to latest version available here: https://llvm.org/viewvc/llvm-project/cfe/trunk/lib/Headers/cpuid.h?view=co
