### PR TITLE
Fix misuse of XFAIL_STATUS

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ RedHat gcc versions)
 
 	/* Transaction aborts come here */
 	unsigned status;
-	XFAIL_STATUS(status);
+	XFAIL_STATUS(abort_handler, status);
 	/* Examine status to determine abort cause */
 	/* Fallback path */
 


### PR DESCRIPTION
I think this is meant to reference `abort_handler`, otherwise the macro expansion doesn't work and `XBEGIN` jumps to a non-existent label.